### PR TITLE
Feature/update to xcode 10.2

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - Nimble (7.0.3)
-  - Quick (1.2.0)
+  - Nimble (8.0.1)
+  - Quick (2.1.0)
   - Spry (3.2.3)
-  - Spry+Nimble (3.2.3):
+  - "Spry+Nimble (3.2.3)":
     - Nimble (> 7.0.0)
     - Spry (= 3.2.3)
 
@@ -10,20 +10,25 @@ DEPENDENCIES:
   - Nimble
   - Quick
   - Spry (from `./../`)
-  - Spry+Nimble (from `./../`)
+  - "Spry+Nimble (from `./../`)"
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Nimble
+    - Quick
 
 EXTERNAL SOURCES:
   Spry:
-    :path: ./../
-  Spry+Nimble:
-    :path: ./../
+    :path: "./../"
+  "Spry+Nimble":
+    :path: "./../"
 
 SPEC CHECKSUMS:
-  Nimble: 7f5a9c447a33002645a071bddafbfb24ea70e0ac
-  Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
-  Spry: c9ee13752a3b456cd8b99fe59f7b8b7c3c290d61
-  Spry+Nimble: b356e1ab8739778cc928d5f8117accfc494684b0
+  Nimble: 45f786ae66faa9a709624227fae502db55a8bdd0
+  Quick: 4be43f6634acfa727dd106bdf3929ce125ffa79d
+  Spry: 6954388f0b17ffe141a73c6160ac8c5af6a5f27b
+  "Spry+Nimble": 5f85b22c9f7133261c18b1b704f17dede00e364b
 
 PODFILE CHECKSUM: e2405578c9aeeb6baa8593874be8985b02f3f677
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.7.0

--- a/Example/SpryExample.xcodeproj/project.pbxproj
+++ b/Example/SpryExample.xcodeproj/project.pbxproj
@@ -253,7 +253,6 @@
 				7A2BFC4D1F00D27E00BB12C1 /* Frameworks */,
 				7A2BFC4E1F00D27E00BB12C1 /* Resources */,
 				58294558D5DA01F7C4A35C40 /* [CP] Embed Pods Frameworks */,
-				93898DB4A8C0B2041CF12E94 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -273,7 +272,6 @@
 				7A2BFC611F00D27E00BB12C1 /* Frameworks */,
 				7A2BFC621F00D27E00BB12C1 /* Resources */,
 				0EFF7EE7C3697C53796F9C55 /* [CP] Embed Pods Frameworks */,
-				22B0F5CAE5E909950E2B4489 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -292,7 +290,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 0830;
+				LastUpgradeCheck = 1010;
 				ORGANIZATIONNAME = "Brian Radebaugh";
 				TargetAttributes = {
 					7A2BFC4F1F00D27E00BB12C1 = {
@@ -314,6 +312,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -355,7 +354,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-SpryExampleTests/Pods-SpryExampleTests-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-SpryExampleTests/Pods-SpryExampleTests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -364,22 +363,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SpryExampleTests/Pods-SpryExampleTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		22B0F5CAE5E909950E2B4489 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SpryExampleTests/Pods-SpryExampleTests-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SpryExampleTests/Pods-SpryExampleTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		58294558D5DA01F7C4A35C40 /* [CP] Embed Pods Frameworks */ = {
@@ -388,7 +372,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-SpryExample/Pods-SpryExample-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-SpryExample/Pods-SpryExample-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
 				"${BUILT_PRODUCTS_DIR}/Spry/Spry.framework",
 				"${BUILT_PRODUCTS_DIR}/Spry+Nimble/Spry_Nimble.framework",
@@ -401,7 +385,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SpryExample/Pods-SpryExample-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SpryExample/Pods-SpryExample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		6997D2DF0B0D6C17FEFA755F /* [CP] Check Pods Manifest.lock */ = {
@@ -420,21 +404,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		93898DB4A8C0B2041CF12E94 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-SpryExample/Pods-SpryExample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F980A5FD39F6CC3612514F0F /* [CP] Check Pods Manifest.lock */ = {
@@ -545,22 +514,32 @@
 		7A2BFC6B1F00D27E00BB12C1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -589,7 +568,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -597,22 +576,32 @@
 		7A2BFC6C1F00D27E00BB12C1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -633,7 +622,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -643,6 +632,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 74E8701AC756C09395104A62 /* Pods-SpryExample.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = XQJAY5KMS4;
 				INFOPLIST_FILE = SpryExample/Info.plist;
@@ -650,7 +640,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = RIV.SpryExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -658,6 +648,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9837E16BB68D3120490898EF /* Pods-SpryExample.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = XQJAY5KMS4;
 				INFOPLIST_FILE = SpryExample/Info.plist;
@@ -665,7 +656,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = RIV.SpryExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -673,7 +664,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B651727304E2FD212D035A72 /* Pods-SpryExampleTests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = XQJAY5KMS4;
@@ -682,7 +673,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = RIV.SpryExampleTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SpryExample.app/SpryExample";
 			};
 			name = Debug;
@@ -691,7 +682,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2862BC607790262CDC9DB580 /* Pods-SpryExampleTests.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = XQJAY5KMS4;
@@ -699,7 +690,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = RIV.SpryExampleTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SpryExample.app/SpryExample";
 			};
 			name = Release;

--- a/Example/SpryExample/AppDelegate.swift
+++ b/Example/SpryExample/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    private func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/Example/SpryExample/AppDelegate.swift
+++ b/Example/SpryExample/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    private func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
@@ -40,7 +40,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
-
-
 }
-

--- a/Example/SpryExampleTests/ArgumentSpec.swift
+++ b/Example/SpryExampleTests/ArgumentSpec.swift
@@ -165,7 +165,7 @@ class ArgumentSpec: QuickSpec {
                                 passedInArg = nil
 
                                 let customValidator = Argument.validator { actualArg -> Bool in
-                                    passedInArg = actualArg as! String
+                                    passedInArg = actualArg as? String
                                     return true
                                 }
 

--- a/Example/SpryExampleTests/Helpers/Stubbable+TestHelper.swift
+++ b/Example/SpryExampleTests/Helpers/Stubbable+TestHelper.swift
@@ -93,6 +93,7 @@ class StubbableTestHelper: Stubbable {
         case giveMeAString_string = "giveMeAString(string:)"
         case giveMeAVoid = "giveMeAVoid()"
         case takeAnOptionalString = "takeAnOptionalString(string:)"
+        case takeUnnamedArgument = "takeUnnamedArgument(_:)"
         case callThisCompletion = "callThisCompletion(string:closure:)"
         case throwingFunction = "throwingFunction()"
     }
@@ -148,6 +149,10 @@ class StubbableTestHelper: Stubbable {
 
     func takeAnOptionalString(string: String?) -> String {
         return stubbedValue(arguments: string)
+    }
+
+    func takeUnnamedArgument(_ unnamed: String) -> Bool {
+        return stubbedValue(arguments: unnamed)
     }
 
     func callThisCompletion(string: String, closure: @escaping () -> Void) {

--- a/Example/SpryExampleTests/StubbableSpec.swift
+++ b/Example/SpryExampleTests/StubbableSpec.swift
@@ -194,6 +194,21 @@ class StubbableSpec: QuickSpec {
                     }
                 }
 
+                context("when there are ONE unnamed argument") {
+                    let expectedString = "expected"
+
+                    beforeEach {
+                        subject.stub(.takeUnnamedArgument).andDo { arguments in
+                            let string = arguments[0] as! String
+                            return string == expectedString
+                        }
+                    }
+
+                    it("should get a string from the stubbed service") {
+                        expect(subject.takeUnnamedArgument(expectedString)).to(beTrue())
+                    }
+                }
+
                 describe("respecting passed in arguments and the return value") {
                     beforeEach {
                         subject.stub(.hereAreTwoStrings).andDo { arguments in

--- a/Example/SpryExampleTests/StubbableSpec.swift
+++ b/Example/SpryExampleTests/StubbableSpec.swift
@@ -194,7 +194,7 @@ class StubbableSpec: QuickSpec {
                     }
                 }
 
-                context("when there are ONE unnamed argument") {
+                context("when there is ONE unnamed argument") {
                     let expectedString = "expected"
 
                     beforeEach {

--- a/Source/Constant.swift
+++ b/Source/Constant.swift
@@ -166,7 +166,3 @@ internal enum Constant {
         }
     }
 }
-
-extension Constant {
-    static let singleUnnamedArgumentFunctionaSuffix = "(_:)"
-}

--- a/Source/Constant.swift
+++ b/Source/Constant.swift
@@ -166,3 +166,7 @@ internal enum Constant {
         }
     }
 }
+
+extension Constant {
+    static let singleUnnamedArgumentFunctionaSuffix = "(_:)"
+}

--- a/Source/SpryEquatable.swift
+++ b/Source/SpryEquatable.swift
@@ -127,7 +127,7 @@ extension Optional: OptionalType {}
 // MARK: - SpryEquatable where Self: OptionalType
 
 public extension SpryEquatable where Self: OptionalType {
-    public func _isEqual(to actual: SpryEquatable?) -> Bool {
+    func _isEqual(to actual: SpryEquatable?) -> Bool {
         let selfMirror = Mirror(reflecting: self)
 
         guard selfMirror.displayStyle == .optional else {

--- a/Source/StringRepresentable.swift
+++ b/Source/StringRepresentable.swift
@@ -25,7 +25,7 @@ public protocol StringRepresentable: RawRepresentable {
 }
 
 public extension StringRepresentable {
-    public init<T>(functionName: String, type: T.Type, file: String, line: Int) {
+    init<T>(functionName: String, type: T.Type, file: String, line: Int) {
         guard let function = Self(rawValue: functionName) else {
             Constant.FatalError.noFunctionFound(functionName: functionName, type: type, file: file, line: line)
         }

--- a/Source/StringRepresentable.swift
+++ b/Source/StringRepresentable.swift
@@ -26,10 +26,21 @@ public protocol StringRepresentable: RawRepresentable {
 
 public extension StringRepresentable {
     init<T>(functionName: String, type: T.Type, file: String, line: Int) {
-        guard let function = Self(rawValue: functionName) else {
+        let hasUnnamedArgumentSuffix = functionName.hasSuffix(Constant.singleUnnamedArgumentFunctionaSuffix)
+
+        if let function = Self(rawValue: functionName) {
+            self = function
+        }
+        else if hasUnnamedArgumentSuffix,
+            let function = Self(rawValue: String(functionName.dropLast(Constant.singleUnnamedArgumentFunctionaSuffix.count))) {
+            self = function
+        }
+        else if !hasUnnamedArgumentSuffix,
+            let function = Self(rawValue: functionName + Constant.singleUnnamedArgumentFunctionaSuffix){
+            self = function
+        }
+        else {
             Constant.FatalError.noFunctionFound(functionName: functionName, type: type, file: file, line: line)
         }
-
-        self = function
     }
 }

--- a/Source/StringRepresentable.swift
+++ b/Source/StringRepresentable.swift
@@ -24,19 +24,21 @@ public protocol StringRepresentable: RawRepresentable {
     init<T>(functionName: String, type: T.Type, file: String, line: Int)
 }
 
+private let singleUnnamedArgumentFunctionaSuffix = "(_:)"
+
 public extension StringRepresentable {
     init<T>(functionName: String, type: T.Type, file: String, line: Int) {
-        let hasUnnamedArgumentSuffix = functionName.hasSuffix(Constant.singleUnnamedArgumentFunctionaSuffix)
+        let hasUnnamedArgumentSuffix = functionName.hasSuffix(singleUnnamedArgumentFunctionaSuffix)
 
         if let function = Self(rawValue: functionName) {
             self = function
         }
         else if hasUnnamedArgumentSuffix,
-            let function = Self(rawValue: String(functionName.dropLast(Constant.singleUnnamedArgumentFunctionaSuffix.count))) {
+            let function = Self(rawValue: String(functionName.dropLast(singleUnnamedArgumentFunctionaSuffix.count))) {
             self = function
         }
         else if !hasUnnamedArgumentSuffix,
-            let function = Self(rawValue: functionName + Constant.singleUnnamedArgumentFunctionaSuffix){
+            let function = Self(rawValue: functionName + singleUnnamedArgumentFunctionaSuffix){
             self = function
         }
         else {

--- a/Spry+Nimble.podspec
+++ b/Spry+Nimble.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author           = { 'Brian Radebaugh' => 'Rivukis@gmail.com' }
   s.source           = { :git => 'https://github.com/Rivukis/Spry.git', :tag => s.version.to_s }
 
-  s.swift_version = '4.0'
+  s.swift_version = '4.2'
   s.ios.deployment_target = '9.0'
   s.source_files = 'SourceNimble/*'
 

--- a/Spry.podspec
+++ b/Spry.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author           = { 'Brian Radebaugh' => 'Rivukis@gmail.com' }
   s.source           = { :git => 'https://github.com/Rivukis/Spry.git', :tag => s.version.to_s }
 
-  s.swift_version = '4.0'
+  s.swift_version = '4.2'
   s.ios.deployment_target = '9.0'
   s.source_files = 'Source/*'
 end


### PR DESCRIPTION
Starting from Xcode 10.2 literal expression `#function` for single unnamed argument function has changed:
**Old** Xcode 10.1 form:
<img width="959" alt="Screen Shot 2019-05-27 at 2 52 43 PM" src="https://user-images.githubusercontent.com/9091182/58418149-a47f5e00-808f-11e9-87a9-382961334b04.png">

**New** Xcode 10.2 form: 
<img width="960" alt="Screen Shot 2019-05-27 at 2 52 00 PM" src="https://user-images.githubusercontent.com/9091182/58418163-b3fea700-808f-11e9-9a8f-d83a4896815d.png">

In this PR I've update logic that initializes enum with raw function String, now it checks whether there is `(_:)` suffix or if not tries to append and initialize function with it. This way it will be backward and future compatible with Xcode 10.1+ version  without need of re-writting any exciting test logic.