### PR TITLE
Change 'class' protocol to 'AnyObject'

### DIFF
--- a/Sources/Spry/Spyable.swift
+++ b/Sources/Spry/Spyable.swift
@@ -22,7 +22,7 @@ private var callsMapTable: NSMapTable<AnyObject, RecordedCallsDictionary> = NSMa
  
  - Note: The `Spryable` protocol exists as a convenience to conform to both `Spyable` and `Stubbable` at the same time.
  */
-public protocol Spyable: class {
+public protocol Spyable: AnyObject {
 
     // MARK: Instance
 

--- a/Sources/Spry/Stubbable.swift
+++ b/Sources/Spry/Stubbable.swift
@@ -22,7 +22,7 @@ private var stubsMapTable: NSMapTable<AnyObject, StubsDictionary> = NSMapTable.w
 
  - Note: The `Spryable` protocol exists as a convenience to conform to both `Spyable` and `Stubbable` at the same time.
  */
-public protocol Stubbable: class {
+public protocol Stubbable: AnyObject {
 
     // MARK: - Instance
 


### PR DESCRIPTION
Resolves Warning: Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead
